### PR TITLE
🏷️ `interface Request extends globalThis.Request`

### DIFF
--- a/src/lib/types/lemmy-js-client.d.ts
+++ b/src/lib/types/lemmy-js-client.d.ts
@@ -1,3 +1,0 @@
-import 'lemmy-js-client'
-
-declare module 'lemmy-js-client' {}

--- a/src/lib/types/undici-types.d.ts
+++ b/src/lib/types/undici-types.d.ts
@@ -1,0 +1,3 @@
+declare module 'undici-types' {
+	interface Request extends globalThis.Request {}
+}


### PR DESCRIPTION
* Workaround for https://github.com/nodejs/undici/issues/1943