### PR TITLE
✅ Add unit tests for comment_tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"lint:fix": "eslint --fix .; pnpm run format --list-different",
 		"format": "prettier --write .",
 		"test:integration": "playwright test",
-		"test:unit": "vitest",
+		"test:unit": "vitest --sequence.concurrent",
 		"generate:android": "capacitor-assets generate --android --iconBackgroundColor '#171717' --iconBackgroundColorDark '#171717' --logoSplashScale 0.5 --splashBackgroundColor '#0A0A0A' --splashBackgroundColorDark '#0A0A0A'",
 		"generate:pwa": "capacitor-assets generate --pwa --pwaManifestPath static/manifest.webmanifest",
 		"ionic:build": "pnpm run build:csr",

--- a/src/lib/comments/CommentNode.svelte
+++ b/src/lib/comments/CommentNode.svelte
@@ -324,7 +324,7 @@
 
 	<!-- Children -->
 	<div class="ml-4 flex flex-col gap-2 border-l border-muted pl-4">
-		{#each children as child (child.comment.comment.id)}
+		{#each children as child (child.view.comment.id)}
 			<svelte:self
 				{allLanguages}
 				{jwt}
@@ -332,7 +332,7 @@
 				{myUser}
 				{site}
 				children={child.children}
-				commentView={child.comment}
+				commentView={child.view}
 				on:comment
 				on:purge
 				personView={undefined}

--- a/src/lib/comments/Comments.svelte
+++ b/src/lib/comments/Comments.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <div class="flex flex-col gap-4 {className}">
-	{#each tree as node (node.comment.comment.id)}
+	{#each tree as node (node.view.comment.id)}
 		<CommentNodeSvelte
 			{allLanguages}
 			{jwt}
@@ -23,7 +23,7 @@
 			{myUser}
 			{site}
 			children={node.children}
-			commentView={node.comment}
+			commentView={node.view}
 			on:block_person
 			on:comment
 			on:purge

--- a/src/lib/comments/comment_node.ts
+++ b/src/lib/comments/comment_node.ts
@@ -1,6 +1,6 @@
-import type { CommentView } from 'lemmy-js-client'
+import type { Comment, CommentView } from 'lemmy-js-client'
 
-export interface CommentNode {
-	readonly children: CommentNode[]
-	readonly comment: CommentView
+export interface CommentNode<T extends { comment: Pick<Comment, 'id' | 'path'> } = CommentView> {
+	readonly children: CommentNode<T>[]
+	readonly view: T
 }

--- a/src/lib/comments/comment_node.ts
+++ b/src/lib/comments/comment_node.ts
@@ -1,6 +1,6 @@
-import type { Comment, CommentView } from 'lemmy-js-client'
+import type { CommentView } from 'lemmy-js-client'
 
-export interface CommentNode<T extends { comment: Pick<Comment, 'id' | 'path'> } = CommentView> {
-	readonly children: CommentNode<T>[]
-	readonly view: T
+export interface CommentNode {
+	readonly children: CommentNode[]
+	readonly view: CommentView
 }

--- a/src/lib/comments/comment_tree.test.ts
+++ b/src/lib/comments/comment_tree.test.ts
@@ -6,7 +6,7 @@ interface TestCommentView {
 	readonly comment: Pick<Comment, 'content' | 'id' | 'path'>
 }
 
-describe('buildCommentTree', () => {
+describe.concurrent('buildCommentTree', () => {
 	test('in a post', ({ expect }) => {
 		const commentViews = [
 			{ comment: { id: 2, path: '0.1.2', content: 'This comment is under #1.' } },

--- a/src/lib/comments/comment_tree.test.ts
+++ b/src/lib/comments/comment_tree.test.ts
@@ -1,0 +1,87 @@
+import type { Comment } from 'lemmy-js-client'
+import { describe, test } from 'vitest'
+import { buildCommentTree } from './comment_tree.js'
+
+interface TestCommentView {
+	readonly comment: Pick<Comment, 'content' | 'id' | 'path'>
+}
+
+describe('buildCommentTree', () => {
+	test('in a post', ({ expect }) => {
+		const commentViews: TestCommentView[] = [
+			{ comment: { id: 2, path: '0.1.2', content: 'This comment is under #1.' } },
+			{ comment: { id: 1, path: '0.1', content: 'This is a top-level comment.' } },
+			{ comment: { id: 3, path: '0.1.3', content: 'This comment is also under #1.' } },
+			{ comment: { id: 4, path: '0.4', content: "This comment is outside of #1's hierarchy." } },
+			{ comment: { id: 5, path: '0.6.5', content: 'This comment will not appear.' } },
+		]
+
+		const tree = buildCommentTree(commentViews, 0)
+
+		expect(tree).toMatchObject([
+			{
+				view: commentViews[1],
+				children: [
+					{ view: commentViews[0], children: [] },
+					{ view: commentViews[2], children: [] },
+				],
+			},
+			{ view: commentViews[3], children: [] },
+		])
+	})
+
+	test('under a parent comment', ({ expect }) => {
+		const commentViews: TestCommentView[] = [
+			{ comment: { id: 1, path: '0.1', content: 'This is the parent comment.' } },
+			{ comment: { id: 2, path: '0.1.2', content: 'This comment is under #1.' } },
+			{ comment: { id: 3, path: '0.1.2.3', content: 'This comment is under #2.' } },
+			{ comment: { id: 4, path: '0.5.4', content: 'This comment will not appear.' } },
+		]
+
+		const tree = buildCommentTree(commentViews, 1)
+
+		expect(tree).toMatchObject([
+			{
+				view: commentViews[0],
+				children: [
+					{
+						view: commentViews[1],
+						children: [{ view: commentViews[2], children: [] }],
+					},
+				],
+			},
+		])
+	})
+
+	test('in a search result', ({ expect }) => {
+		const commentViews: TestCommentView[] = [
+			{ comment: { id: 2, path: '0.1.2', content: 'This comment is under #1.' } },
+			{ comment: { id: 1, path: '0.1', content: 'This is a top-level comment.' } },
+			{ comment: { id: 3, path: '0.4.3', content: "This comment doesn't have a parent." } },
+		]
+
+		const tree = buildCommentTree(commentViews, undefined)
+
+		expect(tree).toMatchObject([
+			{
+				view: commentViews[1],
+				children: [
+					{
+						view: commentViews[0],
+						children: [],
+					},
+				],
+			},
+			{
+				view: commentViews[2],
+				children: [],
+			},
+		])
+	})
+
+	test('with no comments', ({ expect }) => {
+		const commentViews: TestCommentView[] = []
+		const tree = buildCommentTree(commentViews, 0)
+		expect(tree).toEqual([])
+	})
+})

--- a/src/lib/comments/comment_tree.test.ts
+++ b/src/lib/comments/comment_tree.test.ts
@@ -1,4 +1,4 @@
-import type { Comment } from 'lemmy-js-client'
+import type { Comment, CommentView } from 'lemmy-js-client'
 import { describe, test } from 'vitest'
 import { buildCommentTree } from './comment_tree.js'
 
@@ -8,13 +8,13 @@ interface TestCommentView {
 
 describe('buildCommentTree', () => {
 	test('in a post', ({ expect }) => {
-		const commentViews: TestCommentView[] = [
+		const commentViews = [
 			{ comment: { id: 2, path: '0.1.2', content: 'This comment is under #1.' } },
 			{ comment: { id: 1, path: '0.1', content: 'This is a top-level comment.' } },
 			{ comment: { id: 3, path: '0.1.3', content: 'This comment is also under #1.' } },
 			{ comment: { id: 4, path: '0.4', content: "This comment is outside of #1's hierarchy." } },
 			{ comment: { id: 5, path: '0.6.5', content: 'This comment will not appear.' } },
-		]
+		] satisfies TestCommentView[] as CommentView[]
 
 		const tree = buildCommentTree(commentViews, 0)
 
@@ -31,12 +31,12 @@ describe('buildCommentTree', () => {
 	})
 
 	test('under a parent comment', ({ expect }) => {
-		const commentViews: TestCommentView[] = [
+		const commentViews = [
 			{ comment: { id: 1, path: '0.1', content: 'This is the parent comment.' } },
 			{ comment: { id: 2, path: '0.1.2', content: 'This comment is under #1.' } },
 			{ comment: { id: 3, path: '0.1.2.3', content: 'This comment is under #2.' } },
 			{ comment: { id: 4, path: '0.5.4', content: 'This comment will not appear.' } },
-		]
+		] satisfies TestCommentView[] as CommentView[]
 
 		const tree = buildCommentTree(commentViews, 1)
 
@@ -54,11 +54,11 @@ describe('buildCommentTree', () => {
 	})
 
 	test('in a search result', ({ expect }) => {
-		const commentViews: TestCommentView[] = [
+		const commentViews = [
 			{ comment: { id: 2, path: '0.1.2', content: 'This comment is under #1.' } },
 			{ comment: { id: 1, path: '0.1', content: 'This is a top-level comment.' } },
 			{ comment: { id: 3, path: '0.4.3', content: "This comment doesn't have a parent." } },
-		]
+		] satisfies TestCommentView[] as CommentView[]
 
 		const tree = buildCommentTree(commentViews, undefined)
 
@@ -80,7 +80,7 @@ describe('buildCommentTree', () => {
 	})
 
 	test('with no comments', ({ expect }) => {
-		const commentViews: TestCommentView[] = []
+		const commentViews: CommentView[] = []
 		const tree = buildCommentTree(commentViews, 0)
 		expect(tree).toEqual([])
 	})

--- a/src/lib/comments/comment_tree.ts
+++ b/src/lib/comments/comment_tree.ts
@@ -1,17 +1,20 @@
-import type { CommentId, CommentView } from 'lemmy-js-client'
+import type { Comment, CommentId } from 'lemmy-js-client'
 import type { CommentNode } from './comment_node.js'
 
-export function buildCommentTree(commentViews: CommentView[], parentId: CommentId | undefined) {
-	const nodes: CommentNode[] = commentViews.map(c => ({ comment: c, children: [] }))
-	const tree = []
+export function buildCommentTree<T extends { comment: Pick<Comment, 'id' | 'path'> }>(
+	commentViews: T[],
+	parentId: CommentId | undefined,
+) {
+	const nodes: CommentNode<T>[] = commentViews.map(c => ({ view: c, children: [] }))
+	const tree: CommentNode<T>[] = []
 
 	// flat_path = "0.123.456"
 	// node_path = "0.123"
 	// if (flat_path === `${node_path}.${flat_id}`) node.push(flat)
 	for (const flat of nodes) {
 		const node = nodes.find(node => {
-			const { id: flatId, path: flatPath } = flat.comment.comment
-			const { path: nodePath } = node.comment.comment
+			const { id: flatId, path: flatPath } = flat.view.comment
+			const { path: nodePath } = node.view.comment
 
 			// "{0.123}.{456}" === "{0.123.456}"
 			return `${nodePath}.${flatId}` === flatPath
@@ -20,9 +23,9 @@ export function buildCommentTree(commentViews: CommentView[], parentId: CommentI
 		if (node) node.children.push(flat)
 		else if (
 			// Top-level comments are always in the root of the tree.
-			flat.comment.comment.path === `0.${flat.comment.comment.id}` ||
+			flat.view.comment.path === `0.${flat.view.comment.id}` ||
 			// The parent comment itself should be the only root comment.
-			flat.comment.comment.path.endsWith(`.${parentId}`) ||
+			flat.view.comment.path.endsWith(`.${parentId}`) ||
 			// Comments are either top-level or have a parent... except in search results.
 			parentId === undefined
 		)

--- a/src/lib/comments/comment_tree.ts
+++ b/src/lib/comments/comment_tree.ts
@@ -1,12 +1,9 @@
-import type { Comment, CommentId } from 'lemmy-js-client'
+import type { CommentId, CommentView } from 'lemmy-js-client'
 import type { CommentNode } from './comment_node.js'
 
-export function buildCommentTree<T extends { comment: Pick<Comment, 'id' | 'path'> }>(
-	commentViews: T[],
-	parentId: CommentId | undefined,
-) {
-	const nodes: CommentNode<T>[] = commentViews.map(c => ({ view: c, children: [] }))
-	const tree: CommentNode<T>[] = []
+export function buildCommentTree(commentViews: CommentView[], parentId: CommentId | undefined) {
+	const nodes: CommentNode[] = commentViews.map(c => ({ view: c, children: [] }))
+	const tree: CommentNode[] = []
 
 	// flat_path = "0.123.456"
 	// node_path = "0.123"

--- a/src/lib/utils/links.test.ts
+++ b/src/lib/utils/links.test.ts
@@ -1,5 +1,5 @@
 import type { Comment, Community, Person, Post, Site } from 'lemmy-js-client'
-import { test } from 'vitest'
+import { describe, test } from 'vitest'
 import {
 	commentLink,
 	communityLink,
@@ -29,42 +29,44 @@ const person = {
 const post = { id: 456 } satisfies TestPost as Post
 const site = { actor_id: 'https://lemm.ee/' } satisfies TestSite as Site
 
-test('commentLink', ({ expect }) => {
-	const link = commentLink(site, post, comment)
-	expect(link).toBe('/lemm.ee/post/456?parent_id=123')
-})
+describe.concurrent('links', () => {
+	test('commentLink', ({ expect }) => {
+		const link = commentLink(site, post, comment)
+		expect(link).toBe('/lemm.ee/post/456?parent_id=123')
+	})
 
-test('communityLink', ({ expect }) => {
-	const link = communityLink(site, community)
-	expect(link).toBe('/lemm.ee/c/leanish@lemmy.world')
-})
+	test('communityLink', ({ expect }) => {
+		const link = communityLink(site, community)
+		expect(link).toBe('/lemm.ee/c/leanish@lemmy.world')
+	})
 
-test('communityUri', ({ expect }) => {
-	const uri = communityUri(community)
-	expect(uri).toBe('leanish@lemmy.world')
-})
+	test('communityUri', ({ expect }) => {
+		const uri = communityUri(community)
+		expect(uri).toBe('leanish@lemmy.world')
+	})
 
-test('personLink', ({ expect }) => {
-	const link = personLink(site, person)
-	expect(link).toBe('/lemm.ee/u/NatoBoram@lemmy.world')
-})
+	test('personLink', ({ expect }) => {
+		const link = personLink(site, person)
+		expect(link).toBe('/lemm.ee/u/NatoBoram@lemmy.world')
+	})
 
-test('personUri', ({ expect }) => {
-	const uri = personUri(person)
-	expect(uri).toBe('NatoBoram@lemmy.world')
-})
+	test('personUri', ({ expect }) => {
+		const uri = personUri(person)
+		expect(uri).toBe('NatoBoram@lemmy.world')
+	})
 
-test('postLink', ({ expect }) => {
-	const link = postLink(site, post)
-	expect(link).toBe('/lemm.ee/post/456')
-})
+	test('postLink', ({ expect }) => {
+		const link = postLink(site, post)
+		expect(link).toBe('/lemm.ee/post/456')
+	})
 
-test('siteLink', ({ expect }) => {
-	const link = siteLink(site)
-	expect(link).toBe('/lemm.ee')
-})
+	test('siteLink', ({ expect }) => {
+		const link = siteLink(site)
+		expect(link).toBe('/lemm.ee')
+	})
 
-test('siteHostname', ({ expect }) => {
-	const hostname = siteHostname(site)
-	expect(hostname).toBe('lemm.ee')
+	test('siteHostname', ({ expect }) => {
+		const hostname = siteHostname(site)
+		expect(hostname).toBe('lemm.ee')
+	})
 })

--- a/src/lib/utils/links.test.ts
+++ b/src/lib/utils/links.test.ts
@@ -1,0 +1,70 @@
+import type { Comment, Community, Person, Post, Site } from 'lemmy-js-client'
+import { test } from 'vitest'
+import {
+	commentLink,
+	communityLink,
+	communityUri,
+	personLink,
+	personUri,
+	postLink,
+	siteHostname,
+	siteLink,
+} from './links.js'
+
+type TestComment = Pick<Comment, 'id'>
+type TestCommunity = Pick<Community, 'actor_id' | 'name'>
+type TestPerson = Pick<Person, 'actor_id' | 'name'>
+type TestPost = Pick<Post, 'id'>
+type TestSite = Pick<Site, 'actor_id'>
+
+const comment = { id: 123 } satisfies TestComment as Comment
+const community = {
+	actor_id: 'https://lemmy.world/c/leanish',
+	name: 'leanish',
+} satisfies TestCommunity as Community
+const person = {
+	actor_id: 'https://lemmy.world/u/NatoBoram',
+	name: 'NatoBoram',
+} satisfies TestPerson as Person
+const post = { id: 456 } satisfies TestPost as Post
+const site = { actor_id: 'https://lemm.ee/' } satisfies TestSite as Site
+
+test('commentLink', ({ expect }) => {
+	const link = commentLink(site, post, comment)
+	expect(link).toBe('/lemm.ee/post/456?parent_id=123')
+})
+
+test('communityLink', ({ expect }) => {
+	const link = communityLink(site, community)
+	expect(link).toBe('/lemm.ee/c/leanish@lemmy.world')
+})
+
+test('communityUri', ({ expect }) => {
+	const uri = communityUri(community)
+	expect(uri).toBe('leanish@lemmy.world')
+})
+
+test('personLink', ({ expect }) => {
+	const link = personLink(site, person)
+	expect(link).toBe('/lemm.ee/u/NatoBoram@lemmy.world')
+})
+
+test('personUri', ({ expect }) => {
+	const uri = personUri(person)
+	expect(uri).toBe('NatoBoram@lemmy.world')
+})
+
+test('postLink', ({ expect }) => {
+	const link = postLink(site, post)
+	expect(link).toBe('/lemm.ee/post/456')
+})
+
+test('siteLink', ({ expect }) => {
+	const link = siteLink(site)
+	expect(link).toBe('/lemm.ee')
+})
+
+test('siteHostname', ({ expect }) => {
+	const hostname = siteHostname(site)
+	expect(hostname).toBe('lemm.ee')
+})

--- a/src/lib/utils/numbers.test.ts
+++ b/src/lib/utils/numbers.test.ts
@@ -1,0 +1,19 @@
+import { describe, test } from 'vitest'
+import { toSuffixNumber } from './numbers.js'
+
+describe('toSuffixNumber', () => {
+	test('large numbers', ({ expect }) => {
+		expect(toSuffixNumber(9324.86)).toBe('9.32 K')
+		expect(toSuffixNumber(6814206.88)).toBe('6.81 M')
+		expect(toSuffixNumber(1542888068.03)).toBe('1.54 G')
+		expect(toSuffixNumber(9738929036801.75)).toBe('9.74 T')
+		expect(toSuffixNumber(8653033156907251)).toBe('8.65 P')
+		expect(toSuffixNumber(1102757022459672834n)).toBe('1.10 E')
+		expect(toSuffixNumber(1261340892622701723662n)).toBe('1.26 Z')
+		expect(toSuffixNumber(6028979248962363153670258n)).toBe('6.03 Y')
+	})
+
+	test('small numbers', ({ expect }) => {
+		expect(toSuffixNumber(999)).toBe('999')
+	})
+})

--- a/src/lib/utils/numbers.test.ts
+++ b/src/lib/utils/numbers.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from 'vitest'
 import { toSuffixNumber } from './numbers.js'
 
-describe('toSuffixNumber', () => {
+describe.concurrent('toSuffixNumber', () => {
 	test('large numbers', ({ expect }) => {
 		expect(toSuffixNumber(9324.86)).toBe('9.32 K')
 		expect(toSuffixNumber(6814206.88)).toBe('6.81 M')

--- a/src/lib/utils/numbers.ts
+++ b/src/lib/utils/numbers.ts
@@ -1,17 +1,18 @@
-const suffixes = [
+export const suffixes = [
 	{ min: 1_000_000_000_000_000_000_000_000n, suffix: 'Y' },
 	{ min: 1_000_000_000_000_000_000_000n, suffix: 'Z' },
 	{ min: 1_000_000_000_000_000_000n, suffix: 'E' },
-	{ min: 1_000_000_000_000_000n, suffix: 'P' },
-	{ min: 1_000_000_000_000n, suffix: 'T' },
-	{ min: 1_000_000_000n, suffix: 'G' },
-	{ min: 1_000_000n, suffix: 'M' },
-	{ min: 1_000n, suffix: 'K' },
+	{ min: 1_000_000_000_000_000, suffix: 'P' },
+	{ min: 1_000_000_000_000, suffix: 'T' },
+	{ min: 1_000_000_000, suffix: 'G' },
+	{ min: 1_000_000, suffix: 'M' },
+	{ min: 1_000, suffix: 'K' },
 ] as const
 
-export function toSuffixNumber(n: number): string {
-	const bn = BigInt(n)
+export function toSuffixNumber(n: bigint | number): string {
+	const bn = typeof n === 'number' ? BigInt(Math.round(n)) : n
 	const suffix = suffixes.find(({ min }) => bn >= min)
 	if (!suffix) return n.toString()
-	return `${(n / Number(suffix.min)).toFixed(2)} ${suffix.suffix}`
+
+	return `${(Number(n) / Number(suffix.min)).toFixed(2)} ${suffix.suffix}`
 }

--- a/src/lib/utils/requests.test.ts
+++ b/src/lib/utils/requests.test.ts
@@ -1,0 +1,45 @@
+import { describe, test } from 'vitest'
+import { PACKAGE_NAME, PACKAGE_VERSION } from './env.js'
+import { headers } from './requests.js'
+
+describe('headers', () => {
+	test('jwt + user agent', ({ expect }) => {
+		const jwt = 'f8bfe7cc-d301-4151-a1da-d6f2c872370f'
+		const params = { site: 'lemm.ee' }
+		const referer = '/c/leanish@lemmy.world'
+
+		const result = headers(jwt, params, referer)
+
+		expect(result).toEqual({
+			Authorization: `Bearer ${jwt}`,
+			'User-Agent': `${PACKAGE_NAME}@${PACKAGE_VERSION}`,
+		})
+	})
+
+	test('user agent', ({ expect }) => {
+		const jwt = undefined
+		const params = { site: 'lemm.ee' }
+		const referer = '/c/leanish@lemmy.world'
+
+		const result = headers(jwt, params, referer)
+
+		expect(result).toEqual({
+			'User-Agent': `${PACKAGE_NAME}@${PACKAGE_VERSION}`,
+		})
+	})
+
+	test('bypass', ({ expect }) => {
+		const jwt = '40d6adbe-789e-48b1-9ded-e9813aa554d7'
+		const params = { site: 'lemm.ee' }
+		const referer = '/c/leanish@lemmy.world'
+
+		const result = headers(jwt, params, referer, true)
+
+		expect(result).toEqual({
+			Authorization: `Bearer ${jwt}`,
+			Host: params.site,
+			Origin: `https://${params.site}`,
+			Referer: `https://${params.site}${referer}`,
+		})
+	})
+})

--- a/src/lib/utils/requests.test.ts
+++ b/src/lib/utils/requests.test.ts
@@ -1,6 +1,6 @@
-import { describe, test } from 'vitest'
+import { describe, test, vitest } from 'vitest'
 import { PACKAGE_NAME, PACKAGE_VERSION } from './env.js'
-import { headers } from './requests.js'
+import { addAuthBody, addAuthParam, headers, serverFetch } from './requests.js'
 
 describe.concurrent('headers', () => {
 	test('jwt + user agent', ({ expect }) => {
@@ -43,3 +43,55 @@ describe.concurrent('headers', () => {
 		})
 	})
 })
+
+describe.concurrent('serverFetch', () => {
+	test('adds auth to param and body when jwt is provided', async ({ expect }) => {
+		const jwt = '7149c5c8-bf40-48ff-920e-317149873607'
+		const mockedFetch = vitest.fn().mockResolvedValue({ ok: true })
+		const wrappedFetch = serverFetch(mockedFetch, jwt)
+
+		const input = new URL('https://lemm.ee/api/v3/site')
+		const init = { method: 'GET' }
+
+		await wrappedFetch(input, init)
+
+		expect(mockedFetch).toHaveBeenCalledWith(addAuthParam(input, jwt), addAuthBody(init, jwt))
+	})
+
+	test('does not add auth param and body when jwt is not provided', async ({ expect }) => {
+		const jwt = undefined
+		const mockedFetch = vitest.fn().mockResolvedValue({ ok: true })
+		const wrappedFetch = serverFetch(mockedFetch, jwt)
+
+		const input = new URL('https://lemm.ee/api/v3/site')
+		const init = { method: 'GET' }
+
+		await wrappedFetch(input, init)
+
+		expect(mockedFetch).toHaveBeenCalledWith(input, init)
+	})
+
+	test('throws error when response is not ok', async ({ expect }) => {
+		const jwt = '86b8a525-7af5-43c9-b1c5-e09d734e701e'
+		const res = {
+			clone: () => res,
+			headers: new Headers(),
+			ok: false,
+			status: 500,
+			statusText: 'Internal Server Error',
+			text: () => Promise.resolve('Internal Server Error'),
+		} satisfies TestResponse as Response
+		const mockedFetch = vitest.fn().mockResolvedValue(res)
+		const wrappedFetch = serverFetch(mockedFetch, jwt)
+
+		const input = new URL('https://lemm.ee/api/v3/site')
+		const init = { method: 'GET' }
+
+		const wrappedResponse = wrappedFetch(input, init)
+
+		expect(mockedFetch).toHaveBeenCalledWith(addAuthParam(input, jwt), addAuthBody(init, jwt))
+		await expect(wrappedResponse).rejects.toMatchObject(res)
+	})
+})
+
+type TestResponse = Pick<Response, 'clone' | 'headers' | 'ok' | 'status' | 'statusText' | 'text'>

--- a/src/lib/utils/requests.test.ts
+++ b/src/lib/utils/requests.test.ts
@@ -2,7 +2,7 @@ import { describe, test } from 'vitest'
 import { PACKAGE_NAME, PACKAGE_VERSION } from './env.js'
 import { headers } from './requests.js'
 
-describe('headers', () => {
+describe.concurrent('headers', () => {
 	test('jwt + user agent', ({ expect }) => {
 		const jwt = 'f8bfe7cc-d301-4151-a1da-d6f2c872370f'
 		const params = { site: 'lemm.ee' }

--- a/src/lib/utils/requests.ts
+++ b/src/lib/utils/requests.ts
@@ -4,11 +4,16 @@ import { PACKAGE_NAME, PACKAGE_VERSION } from './env.js'
  * don't announce it. */
 const bypass: string[] = []
 
-export function headers(jwt: string | undefined, params: { site: string }, referer: `/${string}`) {
+export function headers(
+	jwt: string | undefined,
+	params: { site: string },
+	referer: `/${string}`,
+	force = false,
+) {
 	return {
 		...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
 
-		...(bypass.includes(params.site)
+		...(bypass.includes(params.site) || force
 			? {
 					Host: params.site,
 					Origin: `https://${params.site}`,

--- a/src/lib/utils/requests.ts
+++ b/src/lib/utils/requests.ts
@@ -68,7 +68,7 @@ export function clientFetch(jwt: string | undefined): typeof globalThis.fetch {
 }
 
 /** Change the `auth` parameter, if there's one, to a random UUID to protect JWT. */
-function removeAuth(input: RequestInfo | URL): string {
+export function removeAuth(input: RequestInfo | URL): string {
 	if (input instanceof URL) {
 		const auth = input.searchParams.get('auth')
 		if (auth) input.searchParams.set('auth', crypto.randomUUID())

--- a/src/lib/utils/requests.ts
+++ b/src/lib/utils/requests.ts
@@ -89,7 +89,7 @@ function removeAuth(input: RequestInfo | URL): string {
 }
 
 /** Add the `auth` parameter to make it compatible with old Lemmy versions. */
-function addAuthParam(input: RequestInfo | URL, jwt: string) {
+export function addAuthParam(input: RequestInfo | URL, jwt: string) {
 	if (input instanceof URL) {
 		input.searchParams.set('auth', jwt)
 		return input.toString()
@@ -107,7 +107,7 @@ function addAuthParam(input: RequestInfo | URL, jwt: string) {
 }
 
 /** Add the `auth` property to make it compatible with old Lemmy versions. */
-function addAuthBody(init: RequestInit | undefined, jwt: string) {
+export function addAuthBody(init: RequestInit | undefined, jwt: string) {
 	if (!init?.body) return init
 
 	const body: unknown = JSON.parse(String(init.body))

--- a/src/routes/[site]/post/[post]/+page.svelte
+++ b/src/routes/[site]/post/[post]/+page.svelte
@@ -30,7 +30,7 @@
 		if (!first) return
 
 		document
-			.querySelector(`[data-comment-id="${first.comment.comment.id}"]`)
+			.querySelector(`[data-comment-id="${first.view.comment.id}"]`)
 			?.scrollIntoView({ block: 'start', behavior: 'smooth' })
 	}
 
@@ -39,7 +39,7 @@
 		if (!last) return
 
 		document
-			.querySelector(`[data-comment-id="${last.comment.comment.id}"]`)
+			.querySelector(`[data-comment-id="${last.view.comment.id}"]`)
 			?.scrollIntoView({ block: 'start', behavior: 'smooth' })
 	}
 
@@ -69,14 +69,14 @@
 		const first = tree[0]
 		if (!first) return false
 
-		return first.comment.comment.path !== `0.${first.comment.comment.id}`
+		return first.view.comment.path !== `0.${first.view.comment.id}`
 	}
 
 	function parentLink(url: URL) {
 		const first = tree[0]
 		if (!first) return
 
-		const paths = first.comment.comment.path.split('.')
+		const paths = first.view.comment.path.split('.')
 		if (paths.length < 3) return
 
 		// Remove 0 and itself

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
 	plugins: [...(https ? [basicSsl()] : []), sveltekit()],
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}'],
+		browser: {
+			name: 'firefox',
+			provider: 'playwright',
+		},
 	},
 	define: {
 		uqy0n95etct89421lezlac5g: `"${env.BUILD_ADAPTER}"`,


### PR DESCRIPTION
This pull request adds unit tests for the comment_tree module, which is responsible for building a comment tree structure based on comment views. The tests cover different scenarios, such as comments in a post, under a parent comment, in a search result, and with no comments.