### PR TITLE
✨ Add monthly GitHub Actions workflow update schedule

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -37,3 +37,10 @@ updates:
       capacitor:
         patterns:
           - '*capacitor*'
+  - package-ecosystem: github-actions
+    directory: /.github/workflows
+    schedule:
+      interval: monthly
+      timezone: America/Toronto
+    commit-message:
+      prefix: '⬆️ '


### PR DESCRIPTION
This pull request adds a monthly update schedule for the GitHub Actions workflows. The schedule is set to run every month in the America/Toronto timezone. This will ensure that the workflows are regularly updated and any necessary changes are applied.