### PR TITLE
Update extension recommendation for vitest.explorer

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,12 @@
 		"ms-azuretools.vscode-docker",
 		"ms-playwright.playwright",
 		"svelte.svelte-vscode",
-		"vscjava.vscode-gradle",
-		"zixuanchen.vitest-explorer"
+		"vitest.explorer",
+		"vscjava.vscode-gradle"
+	],
+	"unwantedRecommendations": [
+		"googlecloudtools.cloudcode",
+		"ms-kubernetes-tools.vscode-kubernetes-tools",
+		"vscodevim.vim"
 	]
 }


### PR DESCRIPTION
This pull request updates the extension recommendation for vitest.explorer in the .vscode/extensions.json file. The unwanted recommendations for googlecloudtools.cloudcode, ms-kubernetes-tools.vscode-kubernetes-tools, and vscodevim.vim have also been removed.