### PR TITLE
🔧 Copy ESLint rules

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -28,9 +28,14 @@ overrides:
     parserOptions:
       parser: '@typescript-eslint/parser'
 rules:
-  '@typescript-eslint/class-methods-use-this': error
+  '@typescript-eslint/class-methods-use-this':
+    - error
+    - ignoreClassesThatImplementAnInterface: true
+      ignoreOverrideMethods: true
   '@typescript-eslint/consistent-type-exports': error
-  '@typescript-eslint/consistent-type-imports': error
+  '@typescript-eslint/consistent-type-imports':
+    - error
+    - fixStyle: separate-type-imports
   '@typescript-eslint/default-param-last': error
   '@typescript-eslint/explicit-member-accessibility':
     - error


### PR DESCRIPTION
This pull request copies the ESLint rules from the `@natoboram/gigachad.ts` repository. The rules include:

```yaml
  '@typescript-eslint/class-methods-use-this':
    - error
    - ignoreClassesThatImplementAnInterface: true
      ignoreOverrideMethods: true
  '@typescript-eslint/consistent-type-imports':
    - error
    - fixStyle: separate-type-imports
```